### PR TITLE
fix(telescope): crashes when used

### DIFF
--- a/lua/jhaime/packer.lua
+++ b/lua/jhaime/packer.lua
@@ -18,7 +18,6 @@ return require("packer").startup(function(use)
 	-- File navigation
 	use({
 		"nvim-telescope/telescope.nvim",
-		tag = "0.1.0",
 		requires = { { "nvim-lua/plenary.nvim" } },
 	})
 


### PR DESCRIPTION
> THIS IS ONLY A WORKAROUND

- Removes the tag. It will be using updated version of telescope.